### PR TITLE
Add check for publishing a package with Same ID but different content.

### DIFF
--- a/src/SleetLib/Commands/PushCommand.cs
+++ b/src/SleetLib/Commands/PushCommand.cs
@@ -184,7 +184,7 @@ namespace Sleet
 
                 if (exists)
                 {
-                    if (await SleetUtility.IsPackageIdenticalOnFeedAsync(package.PackagePath, packageIndex, context.Source, new FlatContainer(context), log) != true)
+                    if (await SleetUtility.IsPackageIdenticalOnFeedAsync(package.PackagePath, packageIndex, context.Source, new FlatContainer(context), log) == false)
                     {
                         await log.LogAsync(LogLevel.Error, $"Trying to re-publish package {packageString} with a different content.");
                         continue;

--- a/src/SleetLib/Commands/PushCommand.cs
+++ b/src/SleetLib/Commands/PushCommand.cs
@@ -184,6 +184,12 @@ namespace Sleet
 
                 if (exists)
                 {
+                    if (await SleetUtility.IsPackageIdenticalOnFeedAsync(package.PackagePath, packageIndex, context.Source, new FlatContainer(context), log) != true)
+                    {
+                        await log.LogAsync(LogLevel.Error, $"Trying to re-publish package {packageString} with a different content.");
+                        continue;
+                    }
+
                     if (skipExisting)
                     {
                         await log.LogAsync(LogLevel.Minimal, $"Skip exisiting package: {packageString}");


### PR DESCRIPTION
Related to this issue: https://github.com/dotnet/core-eng/issues/7551

Adding code to check that whenever we are publishing a package with an Id that already exist on the feed their content is the same.

Sample build where I tested these changes: https://dnceng.visualstudio.com/internal/_build/results?buildId=421232&view=logs&j=9e5e073d-ed1b-557c-5dc4-76882e05596e&t=d4363787-406f-55a7-225c-8c9f76fe169d&l=106 . Follow up changes in Arcade will be necessary.

/cc @jcagme @mmitche @riarenas